### PR TITLE
feat: add standalone synthesis worker

### DIFF
--- a/cli/totalrecall.js
+++ b/cli/totalrecall.js
@@ -10,6 +10,7 @@
  *   recent            - Get recent synthesis nodes
  *   search            - Search synthesis by query
  *   status            - Check system status
+ *   worker            - Run standalone synthesis worker (foreground)
  */
 
 import { fileURLToPath } from 'url';
@@ -96,6 +97,11 @@ async function main() {
         await runCommand(join(srcDir, 'cli', 'status.ts'), args);
         break;
 
+      case 'worker':
+        // Run standalone worker (foreground, for systemd)
+        await runCommand(join(srcDir, 'standalone-worker.ts'), args);
+        break;
+
       case '--help':
       case '-h':
       case undefined:
@@ -116,6 +122,9 @@ User Commands:
                       --format=json|text
   search <query>      Search synthesis by semantic similarity
   status              Check system status
+
+Worker Commands:
+  worker              Run standalone synthesis worker (foreground)
 
 Environment:
   ANTHROPIC_API_KEY   Required for background synthesis

--- a/src/db.ts
+++ b/src/db.ts
@@ -594,6 +594,31 @@ export class SynthesisDatabase {
     this.withRetry(() => stmt.run(id));
   }
 
+  resetStuckSynthesisItems(timeoutMs: number): number {
+    const cutoffTime = Date.now() - timeoutMs;
+    const stmt = this.db.prepare(`
+      UPDATE synthesis_queue
+      SET status = 'pending', retry_count = retry_count + 1
+      WHERE status = 'processing'
+        AND (started_at IS NOT NULL AND started_at < ?)
+        OR (started_at IS NULL AND created_at < ?)
+    `);
+    const result = this.withRetry(() => stmt.run(cutoffTime, cutoffTime));
+    return result.changes;
+  }
+
+  getQueueStats(): { pending: number; processing: number; completed: number; failed: number } {
+    const stats = this.db.prepare(`
+      SELECT
+        COUNT(CASE WHEN status = 'pending' THEN 1 END) as pending,
+        COUNT(CASE WHEN status = 'processing' THEN 1 END) as processing,
+        COUNT(CASE WHEN status = 'completed' THEN 1 END) as completed,
+        COUNT(CASE WHEN status = 'failed' THEN 1 END) as failed
+      FROM synthesis_queue
+    `).get() as { pending: number; processing: number; completed: number; failed: number };
+    return stats;
+  }
+
   // ============ Progressive Disclosure Operations ============
 
   createProgressiveDisclosureEvent(event: Omit<ProgressiveDisclosureEvent, 'id' | 'created_at'>): ProgressiveDisclosureEvent {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -961,19 +961,23 @@ async function main() {
     console.error('Warning: Failed to pre-load embedding model:', e);
   });
 
-  // Initialize synthesis worker if API key is available
+  // Initialize synthesis worker if API key is available and not in standalone mode
   const apiKey = process.env.ANTHROPIC_API_KEY;
-  if (apiKey) {
+  const standaloneMode = process.env.SYNTHESIS_STANDALONE === 'true';
+
+  if (apiKey && !standaloneMode) {
     const llmClient = new LLMSynthesisClient(apiKey);
     synthesisWorker = new SynthesisWorker(db, llmClient, {
-      pollInterval: 30000, // 30 seconds
-      batchSize: 5,
-      maxRetries: 3,
+      pollInterval: parseInt(process.env.SYNTHESIS_POLL_INTERVAL || '30000'),
+      batchSize: parseInt(process.env.SYNTHESIS_BATCH_SIZE || '5'),
+      maxRetries: parseInt(process.env.SYNTHESIS_MAX_RETRIES || '3'),
     });
     synthesisWorker.start().catch((e) => {
       console.error('Failed to start synthesis worker:', e);
     });
-    console.error('Synthesis worker started (ANTHROPIC_API_KEY detected)');
+    console.error('Synthesis worker started (embedded mode)');
+  } else if (standaloneMode) {
+    console.error('Synthesis worker disabled (SYNTHESIS_STANDALONE=true)');
   } else {
     console.error('Synthesis worker disabled (no ANTHROPIC_API_KEY)');
   }

--- a/src/standalone-worker.ts
+++ b/src/standalone-worker.ts
@@ -1,0 +1,105 @@
+/**
+ * Standalone synthesis worker entry point
+ * Runs independently of the MCP server to process synthesis queue
+ */
+
+import { getDatabase, type SynthesisDatabase } from './db.js';
+import { initEmbeddings } from './embeddings.js';
+import { LLMSynthesisClient } from './llm-synthesis.js';
+import { SynthesisWorker } from './synthesis-worker.js';
+
+// Configuration from environment
+interface WorkerConfig {
+  apiKey: string;
+  batchSize: number;
+  pollInterval: number;
+  stuckTimeout: number;
+  maxRetries: number;
+}
+
+function loadConfig(): WorkerConfig {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+
+  if (!apiKey) {
+    console.error('ERROR: ANTHROPIC_API_KEY environment variable is required');
+    process.exit(1);
+  }
+
+  return {
+    apiKey,
+    batchSize: Number(process.env.SYNTHESIS_BATCH_SIZE) || 10,
+    pollInterval: Number(process.env.SYNTHESIS_POLL_INTERVAL) || 10000,
+    stuckTimeout: Number(process.env.SYNTHESIS_STUCK_TIMEOUT) || 300000,
+    maxRetries: Number(process.env.SYNTHESIS_MAX_RETRIES) || 3,
+  };
+}
+
+let db: SynthesisDatabase | null = null;
+let worker: SynthesisWorker | null = null;
+
+async function shutdown(signal: string): Promise<void> {
+  console.log(`\nReceived ${signal}, shutting down gracefully...`);
+
+  if (worker) {
+    await worker.stop();
+    worker = null;
+  }
+
+  if (db) {
+    db.close();
+    db = null;
+  }
+
+  console.log('Shutdown complete');
+  process.exit(0);
+}
+
+async function main(): Promise<void> {
+  const config = loadConfig();
+
+  // Log configuration on startup
+  console.log('Starting Total Recall Synthesis Worker');
+  console.log('Configuration:');
+  console.log(`  Batch Size: ${config.batchSize}`);
+  console.log(`  Poll Interval: ${config.pollInterval}ms`);
+  console.log(`  Stuck Timeout: ${config.stuckTimeout}ms`);
+  console.log(`  Max Retries: ${config.maxRetries}`);
+
+  // Initialize database
+  db = getDatabase();
+  console.log('Database initialized');
+
+  // Pre-load embeddings
+  try {
+    await initEmbeddings();
+  } catch (error) {
+    console.error('Warning: Failed to pre-load embedding model:', error);
+  }
+
+  // Reset stuck items
+  const recovered = db.resetStuckSynthesisItems(config.stuckTimeout);
+  if (recovered > 0) {
+    console.log(`Recovered ${recovered} stuck synthesis items`);
+  }
+
+  // Create LLM client and worker
+  const llmClient = new LLMSynthesisClient(config.apiKey);
+  worker = new SynthesisWorker(db, llmClient, {
+    batchSize: config.batchSize,
+    pollInterval: config.pollInterval,
+    maxRetries: config.maxRetries,
+  });
+
+  // Setup graceful shutdown handlers
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+  process.on('SIGINT', () => shutdown('SIGINT'));
+
+  // Start worker
+  await worker.start();
+  console.log('Synthesis worker is now running');
+}
+
+main().catch((error) => {
+  console.error('Fatal error starting synthesis worker:', error);
+  process.exit(1);
+});

--- a/worker-wrapper.sh
+++ b/worker-wrapper.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Total Recall Standalone Synthesis Worker
+# Portable wrapper for NixOS, Docker, systemd
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source environment if available (bhakti-specific)
+if [[ -f /run/secrets/rendered/coordinator-env ]]; then
+    set -a
+    source /run/secrets/rendered/coordinator-env
+    set +a
+fi
+
+# NixOS: Set LD_LIBRARY_PATH for native modules that need libstdc++
+GCC_LIB=$(find /nix/store -maxdepth 1 -name "*-gcc-*-lib" -type d 2>/dev/null | head -1)
+if [[ -n "$GCC_LIB" ]]; then
+    export LD_LIBRARY_PATH="${GCC_LIB}/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi
+
+# Find bun in common locations (Docker containers, NixOS, standard installs)
+find_bun() {
+    local candidates=(
+        "$HOME/.bun/bin/bun"           # User install (Docker dev user)
+        "/home/dev/.bun/bin/bun"       # Docker container dev user
+        "/home/ramram/.bun/bin/bun"    # bhakti ramram user
+        "$(command -v bun 2>/dev/null)" # In PATH
+    )
+    for candidate in "${candidates[@]}"; do
+        if [[ -x "$candidate" ]]; then
+            echo "$candidate"
+            return 0
+        fi
+    done
+    echo "bun"  # Fallback to PATH lookup
+}
+
+BUN_PATH=$(find_bun)
+exec "$BUN_PATH" "${SCRIPT_DIR}/dist/standalone-worker.js" "$@"


### PR DESCRIPTION
## Summary
- Adds standalone synthesis worker that runs independently of MCP server
- Configurable via environment variables: `SYNTHESIS_BATCH_SIZE`, `SYNTHESIS_POLL_INTERVAL`, `SYNTHESIS_STUCK_TIMEOUT`
- Includes recovery logic for stuck items on startup
- MCP server can disable embedded worker with `SYNTHESIS_STANDALONE=true`

## Files Added/Modified
- `src/standalone-worker.ts` - Main worker entry point
- `src/db.ts` - Added `resetStuckSynthesisItems()` and `getQueueStats()`
- `src/mcp-server.ts` - Added standalone mode flag
- `cli/totalrecall.js` - Added `worker` command
- `worker-wrapper.sh` - Portable wrapper for systemd/Docker

## Test Plan
- [x] Worker starts and polls queue
- [x] Stuck items recovered on startup
- [x] MCP server disables embedded worker when `SYNTHESIS_STANDALONE=true`
- [ ] Deploy to bhakti as systemd service

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)