### PR TITLE
feat: add per-message memory enrichment via UserPromptSubmit hook

### DIFF
--- a/cli/totalrecall.js
+++ b/cli/totalrecall.js
@@ -63,6 +63,10 @@ async function main() {
         await runCommand(join(srcDir, 'cli', 'session-graft.ts'), args);
         break;
 
+      case 'prompt-enrich':
+        await runCommand(join(srcDir, 'cli', 'prompt-enrich.ts'), args);
+        break;
+
       case 'session-complete':
         await runCommand(join(srcDir, 'cli', 'session-complete.ts'), args);
         break;
@@ -115,6 +119,7 @@ Usage: totalrecall <command> [options]
 
 Hook Commands (called automatically):
   session-graft       Graft session to synthesis graph
+  prompt-enrich       Inject relevant memories per user prompt
   session-complete    Complete session with summary
   queue-synthesis     Queue current session for background synthesis
   backfill            Backfill unprocessed conversations
@@ -138,8 +143,9 @@ Maintenance Commands:
                       --dry-run       Preview without changes
 
 Environment:
-  ANTHROPIC_API_KEY   Required for background synthesis
-  TRANSCRIPT_PATH     Set by Claude Code hooks
+  ANTHROPIC_API_KEY     Required for background synthesis
+  TRANSCRIPT_PATH       Set by Claude Code hooks
+  TOTALRECALL_ENRICH    Set to 'false' to disable per-prompt enrichment
 `);
         break;
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/cli/totalrecall.js prompt-enrich",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "matcher": "startup|resume",

--- a/src/cli/prompt-enrich.ts
+++ b/src/cli/prompt-enrich.ts
@@ -1,0 +1,91 @@
+/**
+ * CLI: prompt-enrich
+ * Called by UserPromptSubmit hook to inject relevant memory context per-message
+ *
+ * Reads user prompt from stdin, performs semantic search, and outputs
+ * ~200 tokens of relevant synthesis nodes as additionalContext.
+ */
+
+import { getDatabase } from '../db.js';
+import { generateEmbedding, initEmbeddings } from '../embeddings.js';
+
+interface HookInput {
+  prompt?: string;
+  transcript_path?: string;
+}
+
+const MIN_SCORE = 0.5; // Higher threshold for relevance
+const MAX_RESULTS = 4; // ~200 tokens (4 one-liners at ~50 tokens each)
+
+async function main() {
+  // Check for disable toggle
+  if (process.env.TOTALRECALL_ENRICH === 'false') {
+    process.exit(0);
+  }
+
+  // Read hook input from stdin
+  let input: HookInput = {};
+  try {
+    const chunks: Buffer[] = [];
+    for await (const chunk of process.stdin) {
+      chunks.push(chunk);
+    }
+    const stdinData = Buffer.concat(chunks).toString('utf-8').trim();
+    if (stdinData) {
+      input = JSON.parse(stdinData);
+    }
+  } catch {
+    // No stdin or invalid JSON - skip enrichment
+    process.exit(0);
+  }
+
+  const prompt = input.prompt;
+  if (!prompt || prompt.length < 10) {
+    // Skip very short prompts (likely commands or acknowledgments)
+    process.exit(0);
+  }
+
+  try {
+    // Initialize embeddings (cold start ~1-2s)
+    await initEmbeddings();
+
+    // Generate embedding for user's prompt
+    const queryEmbedding = await generateEmbedding(prompt);
+
+    // Search for relevant synthesis nodes
+    const db = getDatabase();
+    const results = db.searchByVector(queryEmbedding, MAX_RESULTS, MIN_SCORE);
+    db.close();
+
+    if (results.length === 0) {
+      // No relevant context found - don't inject noise
+      process.exit(0);
+    }
+
+    // Format results as one-liners
+    const contextLines = results
+      .map((r) => `- [${r.node_type}] ${r.one_liner} (${r.node_id.slice(0, 8)})`)
+      .join('\n');
+
+    // Output hook response
+    console.log(
+      JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: 'UserPromptSubmit',
+          additionalContext: `<total_recall_relevant>
+Relevant memories for your query:
+${contextLines}
+
+Use synthesis_unfold(node_id) for more detail.
+</total_recall_relevant>`,
+        },
+      })
+    );
+  } catch (error) {
+    // On error, fail silently to not block user prompt
+    console.error(`[totalrecall] prompt-enrich error: ${error}`);
+    process.exit(0);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

- Adds `UserPromptSubmit` hook to inject relevant memory context (~200 tokens) on every user message
- Creates `prompt-enrich` CLI command that performs semantic search against user prompts
- Uses higher similarity threshold (0.5) for accuracy
- Adds `TOTALRECALL_ENRICH=false` toggle to disable

**Before:** Memory context only injected at SessionStart (~5 recent nodes)
**After:** Each user message gets semantically relevant memories injected

### Example output

```
<total_recall_relevant>
Relevant memories for your query:
- [learning] How to implement hooks in Claude Code (ff97e1a1)
- [decision] Use UserPromptSubmit for per-message injection (abbb2637)

Use synthesis_unfold(node_id) for more detail.
</total_recall_relevant>
```

## Test plan

- [x] Verify `prompt-enrich.ts` compiles
- [x] Test with sample prompt - returns relevant memories
- [x] Test with irrelevant prompt - returns nothing (no noise)
- [ ] Test cold start latency in real usage (embedding model load time)

## Notes

- 5s timeout should accommodate embedding model cold start
- Falls back silently on errors to not block user prompts
- Skips prompts < 10 chars (likely commands/acknowledgments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)